### PR TITLE
feature : added structured logging with slog for improved observability

### DIFF
--- a/src/int_test.go
+++ b/src/int_test.go
@@ -3,9 +3,10 @@ package main
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"os"
-	"sync"
 	"os/signal"
+	"sync"
 	"syscall"
 	"testing"
 
@@ -14,6 +15,7 @@ import (
 
 func TestIntegration(t *testing.T) {
 	redisAddr := "localhost:6379"
+	log := slog.New(slog.NewJSONHandler(os.Stdout, nil))
 
 	client := redis.NewClient(&redis.Options{Addr: redisAddr})
 	defer client.Close()
@@ -21,11 +23,11 @@ func TestIntegration(t *testing.T) {
 		t.Errorf("Failed to connect to Redis: %v", err)
 	}
 
-	scheduler := NewScheduler(redisAddr)
+	scheduler := NewScheduler(redisAddr, log)
 	defer scheduler.Close()
 
 	consumerID := fmt.Sprintf("worker_%d", os.Getpid())
-	supervisor := NewSupervisor(redisAddr, consumerID, "AMD")
+	supervisor := NewSupervisor(redisAddr, consumerID, "AMD", log)
 
 	if err := supervisor.Start(); err != nil {
 		t.Errorf("Failed to start supervisor: %v", err)
@@ -36,7 +38,7 @@ func TestIntegration(t *testing.T) {
 
 	// test jobs
 	var wg sync.WaitGroup
-    wg.Add(1)
+	wg.Add(1)
 	go func() {
 		defer wg.Done()
 		jobTypes := []string{"a", "b", "c"}
@@ -52,7 +54,7 @@ func TestIntegration(t *testing.T) {
 			}
 		}
 	}()
-	
+
 	wg.Wait()
 	supervisor.Stop()
 }

--- a/src/scheduler.go
+++ b/src/scheduler.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"log"
+	"log/slog"
 	"time"
 
 	"github.com/redis/go-redis/v9"
@@ -13,9 +13,10 @@ import (
 type Scheduler struct {
 	client *redis.Client
 	ctx    context.Context
+	log    *slog.Logger
 }
 
-func NewScheduler(redisAddr string) *Scheduler {
+func NewScheduler(redisAddr string, log *slog.Logger) *Scheduler {
 	client := redis.NewClient(&redis.Options{
 		Addr: redisAddr,
 	})
@@ -23,6 +24,7 @@ func NewScheduler(redisAddr string) *Scheduler {
 	return &Scheduler{
 		client: client,
 		ctx:    context.Background(),
+		log:    log,
 	}
 }
 
@@ -52,7 +54,7 @@ func (s *Scheduler) Enqueue(jobType string, payload map[string]interface{}) erro
 		return fmt.Errorf("failed to enqueue job: %w", result.Err())
 	}
 
-	log.Printf("Enqueued job %s of type %s", job.ID, job.Type)
+	s.log.Info("enqueued job", "job_id", job.ID, "job_type", job.Type)
 	return nil
 }
 


### PR DESCRIPTION
closes #27 

key updates : 
- switched to local logging instead of global logging
- switched log to slog 

example logs with redis down : 
<img width="1317" height="236" alt="Screenshot 2025-09-02 at 2 53 39 PM" src="https://github.com/user-attachments/assets/8950fd4c-1be2-484f-8825-ad8c4e5a09f3" />

example logs with redis running : 
<img width="1293" height="152" alt="Screenshot 2025-09-02 at 2 54 22 PM" src="https://github.com/user-attachments/assets/017821da-14ed-424d-a402-96be5022376f" />
