### PR TITLE
feature : file based logging

### DIFF
--- a/config/log.yaml
+++ b/config/log.yaml
@@ -1,0 +1,10 @@
+output:
+  types:
+    - file
+    - stdout
+  directory: ./logs/
+
+components:
+  - app
+  - scheduler
+  - supervisor

--- a/src/api.go
+++ b/src/api.go
@@ -100,7 +100,11 @@ func (a *App) Shutdown(ctx context.Context) error {
 }
 
 func main() {
-	log := slog.New(slog.NewJSONHandler(os.Stdout, nil))
+	log, err := createLogger("app")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to create logger: %v\n", err)
+		os.Exit(1)
+	}
 	app := NewApp("localhost:6379", "AMD", log)
 
 	if err := app.Start(); err != nil {

--- a/src/go.mod
+++ b/src/go.mod
@@ -7,4 +7,5 @@ require github.com/redis/go-redis/v9 v9.10.0
 require (
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/src/go.sum
+++ b/src/go.sum
@@ -8,3 +8,6 @@ github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f h1:lO4WD4F/r
 github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f/go.mod h1:cuUVRXasLTGF7a8hSLbxyZXjz+1KgoB3wDUb6vlszIc=
 github.com/redis/go-redis/v9 v9.10.0 h1:FxwK3eV8p/CQa0Ch276C7u2d0eNC9kCmAYQ7mCXCzVs=
 github.com/redis/go-redis/v9 v9.10.0/go.mod h1:huWgSWd8mW6+m0VPhJjSSQ+d6Nh1VICQ6Q5lHuCH/Iw=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/src/log.go
+++ b/src/log.go
@@ -1,0 +1,99 @@
+package main
+
+import (
+	"context"
+	"gopkg.in/yaml.v3"
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+)
+
+const LogConfigFilePath = "../config/log.yaml"
+
+type MultiHandler struct {
+	subHandlers []slog.Handler
+	level       slog.Level
+}
+
+type LogConfig struct {
+	Output struct {
+		Types     []string `yaml:"types"`
+		Directory string   `yaml:"directory"`
+	} `yaml:"output"`
+	Components []string `yaml:"components"`
+}
+
+func NewMultiHandler(level slog.Level, writers []io.Writer) *MultiHandler {
+	var handlers []slog.Handler
+
+	for _, writer := range writers {
+		handlers = append(handlers, slog.NewJSONHandler(writer, nil))
+	}
+
+	m := MultiHandler{
+		level:       level,
+		subHandlers: handlers,
+	}
+	return &m
+}
+
+func (h *MultiHandler) Enabled(ctx context.Context, level slog.Level) bool { return h.level <= level }
+func (h *MultiHandler) WithAttrs(attrs []slog.Attr) slog.Handler           { return h }
+func (h *MultiHandler) WithGroup(name string) slog.Handler                 { return h }
+func (h *MultiHandler) Handle(ctx context.Context, record slog.Record) error {
+	var err error
+	for _, handler := range h.subHandlers {
+		if out := handler.Handle(ctx, record); out != nil {
+			err = out
+		}
+	}
+	return err
+}
+
+func getLogConfig(file string) (LogConfig, error) {
+	var config LogConfig
+
+	configFile, err := os.ReadFile(file)
+	if err != nil {
+		return config, err
+	}
+
+	err = yaml.Unmarshal(configFile, &config)
+	if err != nil {
+		return config, err
+	}
+
+	return config, nil
+}
+
+func createLogger(component string) (*slog.Logger, error) {
+	logConfig, err := getLogConfig(LogConfigFilePath)
+	if err != nil {
+		return nil, err
+	}
+	var writers []io.Writer
+	for _, t := range logConfig.Output.Types {
+		switch t {
+		case "stdout":
+			writers = append(writers, os.Stdout)
+		case "file":
+			directory := logConfig.Output.Directory
+
+			if err := os.MkdirAll(directory, 0755); err != nil {
+				return nil, err
+			}
+
+			filePath := filepath.Join(directory, component+".log")
+			file, err := os.OpenFile(filePath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0644)
+			if err != nil {
+				return nil, err
+			}
+			writers = append(writers, file)
+
+		}
+	}
+	handler := NewMultiHandler(slog.LevelInfo, writers)
+	logger := slog.New(handler).With("component", component)
+	return logger, nil
+}


### PR DESCRIPTION
closes #39 
related to : #32 

Implemented a custom slog.Handler that writes logs to multiple destinations (e.g., files, stdout) simultaneously.