### PR TITLE
improved log setup failures with a fallback logger to os.Stderr

### DIFF
--- a/src/log_test.go
+++ b/src/log_test.go
@@ -1,0 +1,1 @@
+package main


### PR DESCRIPTION
closes #41

**Description** 

This PR improves robustness in logger setup by ensuring that `createLogger` never returns a nil logger even if:

- The log configuration file is missing or invalid
- The log directory cannot be created
- Log files cannot be opened

A fallback logger is returned that writes to `stderr` at `DEBUG` level ensuring the application can always safely log messages.